### PR TITLE
fixed issue #10

### DIFF
--- a/src/main/java/net/twentyonesolutions/lucee/websocket/HandshakeHandler.java
+++ b/src/main/java/net/twentyonesolutions/lucee/websocket/HandshakeHandler.java
@@ -116,7 +116,15 @@ public class HandshakeHandler extends ServerEndpointConfig.Configurator {
 
 				Map<String, String> cookies = parseRequestHeaderCookie(rawCookies.get(0));
 
-				idCookieValue = cookies.get(idCookieName);
+				String realkey = idCookieName;
+
+				for (String c : cookies.keySet()){
+					if (c.equalsIgnoreCase(idCookieName)){
+						realkey = c;
+					 }
+				 }
+
+				idCookieValue = cookies.get(realkey);
 				if (idCookieValue != null)
 					userProps.put(idCookieName, idCookieValue); // store cfid in UserProperties for future use
 			}


### PR DESCRIPTION
the issue I found with some browsers is that cookies were stored in either lower or upper case. When grabbing the cfid value, if it was uppercase, it would set it to null. This change gets the real key using a no case comparison. 